### PR TITLE
Added possibility to format dates over typoscript + no absolute URLs in pagination

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -1,7 +1,7 @@
 plugin.tx_news {
-    view {
-        templateRootPath = EXT:headless_news/Resources/Private/News/Templates/
-        partialRootPath = EXT:headless_news/Resources/Private/News/Partials/
-        layoutRootPath = EXT:headless_news/Resources/Private/News/Layouts/
-    }
+  view {
+    templateRootPath = EXT:headless_news/Resources/Private/News/Templates/
+    partialRootPath = EXT:headless_news/Resources/Private/News/Partials/
+    layoutRootPath = EXT:headless_news/Resources/Private/News/Layouts/
+  }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,27 +1,31 @@
 tt_content.list =< lib.contentElementWithHeader
 tt_content.list {
-    fields {
-        content {
-            fields {
-                data = CASE
-                data {
-                    key.field = list_type
+  fields {
+    content {
+      fields {
+        data = CASE
+        data {
+          key.field = list_type
 
-                    news_pi1 = USER
-                    news_pi1 {
-                        userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
-                        vendorName = GeorgRinger
-                        extensionName = News
-                        pluginName = Pi1
-                        controller = News
-
-                        view < plugin.tx_news.view
-                        persistence < plugin.tx_news.persistence
-                        settings < plugin.tx_news.settings
-                    }
-                }
+          news_pi1 = USER
+          news_pi1 {
+            userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
+            vendorName = GeorgRinger
+            extensionName = News
+            pluginName = Pi1
+            controller = News
+            view < plugin.tx_news.view
+            persistence < plugin.tx_news.persistence
+            settings < plugin.tx_news.settings
+            settings {
+              dateFormat = TEXT
+              dateFormat = M d Y
+              dateTimeFormat = TEXT
+              dateTimeFormat = Y-m-d H:i:s
             }
-
+          }
         }
+      }
     }
+  }
 }

--- a/Resources/Private/News/Partials/List/Pagination.html
+++ b/Resources/Private/News/Partials/List/Pagination.html
@@ -5,19 +5,19 @@
 
 <f:if condition="{pagination.previousPageNumber} && {pagination.previousPageNumber} >= {pagination.firstPageNumber}">
     <f:variable name="prev"
-                value="{f:uri.action(action:actionName, arguments:{currentPage: pagination.previousPageNumber}, addQueryString:1, absolute: 1)}"/>
+                value="{f:uri.action(action:actionName, arguments:{currentPage: pagination.previousPageNumber}, addQueryString:1)}"/>
 </f:if>
 
 <f:if condition="{pagination.nextPageNumber} && {pagination.nextPageNumber} <= {pagination.lastPageNumber}">
     <f:variable name="next"
-                value="{f:uri.action(action:actionName, arguments:{currentPage: pagination.nextPageNumber}, addQueryString:1, absolute: 1)}"/>
+                value="{f:uri.action(action:actionName, arguments:{currentPage: pagination.nextPageNumber}, addQueryString:1)}"/>
 </f:if>
 
 <f:spaceless>
     <f:format.raw>
         <f:format.json value="{
-            first: '{f:uri.action(action:actionName, arguments:{currentPage: 1}, addQueryString:1, absolute: 1)}',
-            last: '{f:uri.action(action:actionName, arguments:{currentPage: pagination.lastPageNumber},addQueryString:1, absolute: 1)}',
+            first: '{f:uri.action(action:actionName, arguments:{currentPage: 1}, addQueryString:1)}',
+            last: '{f:uri.action(action:actionName, arguments:{currentPage: pagination.lastPageNumber},addQueryString:1)}',
             prev: prev,
             next: next,
             pages: '{f:render(section: \'Pages\', arguments: \'{_all}\') -> headless:format.json.decode()}'
@@ -32,7 +32,7 @@
             <f:for each="{pagination.allPageNumbers}" as="page" iteration="iterator">
                 <f:format.json value="{
                 page: '{page}',
-                link: '{f:uri.action(action:actionName, arguments:{currentPage: page},addQueryString:1, absolute: 1)}',
+                link: '{f:uri.action(action:actionName, arguments:{currentPage: page},addQueryString:1}',
                 current: '{f:if(condition: \'{page} == {paginator.currentPageNumber}\', then: 1, else: 0)}'
             }"/>
                 {f:if(condition: iterator.isLast, else: ',')}

--- a/Resources/Private/News/Partials/List/Pagination.html
+++ b/Resources/Private/News/Partials/List/Pagination.html
@@ -32,7 +32,7 @@
             <f:for each="{pagination.allPageNumbers}" as="page" iteration="iterator">
                 <f:format.json value="{
                 page: '{page}',
-                link: '{f:uri.action(action:actionName, arguments:{currentPage: page},addQueryString:1}',
+                link: '{f:uri.action(action:actionName, arguments:{currentPage: page},addQueryString:1)}',
                 current: '{f:if(condition: \'{page} == {paginator.currentPageNumber}\', then: 1, else: 0)}'
             }"/>
                 {f:if(condition: iterator.isLast, else: ',')}

--- a/Resources/Private/News/Partials/Media/Type/Application.html
+++ b/Resources/Private/News/Partials/Media/Type/Application.html
@@ -11,8 +11,8 @@
             description: file.description,
             mimetype: file.mimetype,
             publicUrl: '{f:uri.typolink(parameter: file.publicUrl, absolute: absolute)}',
-            creationTime: '{f:if(condition: file.creationTime, then: \'{file.creationTime -> f:format.date(format: \\\'Y-m-d\ H:i:s\\\')}\')}',
-            modificationTime: '{f:if(condition: file.modificationTime, then: \'{file.modificationTime -> f:format.date(format: \\\'Y-m-d\ H:i:s\\\')}\')}'
+            creationTime: '{f:if(condition: file.creationTime, then: \'{file.creationTime -> f:format.date(format: settings.dateTimeFormat)}\')}',
+            modificationTime: '{f:if(condition: file.modificationTime, then: \'{file.modificationTime -> f:format.date(format: settings.dateTimeFormat)}\')}'
         }
       }"/>
   </f:format.raw>

--- a/Resources/Private/News/Partials/Media/Type/Audio.html
+++ b/Resources/Private/News/Partials/Media/Type/Audio.html
@@ -26,8 +26,8 @@
             mimetype: audio.mimetype,
             source: '{f:uri.typolink(parameter: audio.publicUrl, absolute: absolute)}',
             autoplay: '{autoplay -> headless:format.json.decode()}',
-            creationTime: '{f:if(condition: audio.creationTime, then: \'{audio.creationTime -> f:format.date(format: \\\'Y-m-d\ H:i:s\\\')}\')}',
-            modificationTime: '{f:if(condition: audio.modificationTime, then: \'{audio.modificationTime -> f:format.date(format: \\\'Y-m-d\ H:i:s\\\')}\')}'
+            creationTime: '{f:if(condition: audio.creationTime, then: \'{audio.creationTime -> f:format.date(format: settings.dateTimeFormat)}\')}',
+            modificationTime: '{f:if(condition: audio.modificationTime, then: \'{audio.modificationTime -> f:format.date(format: settings.dateTimeFormat)}\')}'
       }}"/>
   </f:format.raw>
 </f:spaceless>

--- a/Resources/Private/News/Partials/Media/Type/Image.html
+++ b/Resources/Private/News/Partials/Media/Type/Image.html
@@ -64,8 +64,8 @@
         link: '{f:uri.typolink(parameter: image.link)}',
         mimetype: image.originalResource.mimetype,
         showInPreview: image.showinpreview,
-        creationTime: '{f:if(condition: image.originalResource.creationTime, then: \'{image.originalResource.creationTime -> f:format.date(format: \\\'Y-m-d\ H:i:s\\\')}\')}',
-        modificationTime: '{f:if(condition: image.originalResource.modificationTime, then: \'{image.originalResource.modificationTime -> f:format.date(format: \\\'Y-m-d\ H:i:s\\\')}\')}'
+        creationTime: '{f:if(condition: image.originalResource.creationTime, then: \'{image.originalResource.creationTime -> f:format.date(format: settings.dateTimeFormat)}\')}',
+        modificationTime: '{f:if(condition: image.originalResource.modificationTime, then: \'{image.originalResource.modificationTime -> f:format.date(format: settings.dateTimeFormat)}\')}'
       },
       images: {
         defaultImage: {

--- a/Resources/Private/News/Partials/Media/Type/Video.html
+++ b/Resources/Private/News/Partials/Media/Type/Video.html
@@ -26,8 +26,8 @@
             mimetype: video.mimetype,
             source: '{f:if(condition: \'{video.extension} == \\\'youtube\\\' || {video.extension} == \\\'vimeo\\\'\', then: video.publicUrl, else: \'{f:uri.typolink(parameter: video.publicUrl, absolute: absolute)}\')}',
             autoplay: '{autoplay -> headless:format.json.decode()}',
-            creationTime: '{f:if(condition: video.creationTime, then: \'{video.creationTime -> f:format.date(format: \\\'Y-m-d\TH:i:sP\\\')}\')}',
-            modificationTime: '{f:if(condition: video.modificationTime, then: \'{video.modificationTime -> f:format.date(format: \\\'Y-m-d\TH:i:sP\\\')}\')}'
+            creationTime: '{f:if(condition: video.creationTime, then: \'{video.creationTime -> f:format.date(format: settings.dateTimeFormat')}\')}',
+            modificationTime: '{f:if(condition: video.modificationTime, then: \'{video.modificationTime -> f:format.date(format: \settings.dateTimeFormat)}\')}'
       }}"
     />
   </f:format.raw>

--- a/Resources/Private/News/Templates/News/Detail.html
+++ b/Resources/Private/News/Templates/News/Detail.html
@@ -15,10 +15,10 @@
                     teaser: newsItem.teaser,
                     isTopNews: newsItem.istopnews,
                     bodytext: '{newsItem.bodytext -> f:format.html(parseFuncTSPath: \'lib.parseFunc_links\')}',
-                    crdate: '{f:if(condition: newsItem.crdate, then: \'{newsItem.crdate -> f:format.date(format: \\\'M\ d\ Y\\\')}\')}',
-                    tstamp: '{f:if(condition: newsItem.tstamp, then: \'{newsItem.tstamp -> f:format.date(format: \\\'M\ d\ Y\\\')}\')}',
-                    datetime: '{f:if(condition: newsItem.datetime, then: \'{newsItem.datetime -> f:format.date(format: \\\'M\ d\ Y\\\')}\')}',
-                    archive: '{f:if(condition: newsItem.archive, then: \'{newsItem.archive -> f:format.date(format: \\\'M\ d\ Y\\\')}\')}',
+                    crdate: '{f:if(condition: newsItem.crdate, then: \'{newsItem.crdate -> f:format.date(format: settings.dateFormat)}\')}',
+                    tstamp: '{f:if(condition: newsItem.tstamp, then: \'{newsItem.tstamp -> f:format.date(format: settings.dateFormat)}\')}',
+                    datetime: '{f:if(condition: newsItem.datetime, then: \'{newsItem.datetime -> f:format.date(format: settings.dateFormat)}\')}',
+                    archive: '{f:if(condition: newsItem.archive, then: \'{newsItem.archive -> f:format.date(format: settings.dateFormat)}\')}',
                     author: {
                       author: newsItem.author,
                       authorEmail: newsItem.authorEmail

--- a/Resources/Private/News/Templates/News/Detail.html
+++ b/Resources/Private/News/Templates/News/Detail.html
@@ -33,7 +33,8 @@
                       alternativeTitle: newsItem.alternativeTitle
                     },
                     pathSegment: newsItem.pathSegment,
-                    canonical: '{f:uri.page(pageUid: newsItem.canonical, additionalParams: \'{tx_news_pi1: \\\'{news: newsItem.uid, action: \\\\\\\'detail\\\\\\\', controller: \\\\\\\'News\\\\\\\'}\\\'}\')}'
+                    canonical: '{f:uri.page(pageUid: newsItem.canonical, additionalParams: \'{tx_news_pi1: \\\'{news: newsItem.uid, action: \\\\\\\'detail\\\\\\\', controller: \\\\\\\'News\\\\\\\'}\\\'}\')}',
+                    backLink: '{f:translate(key: \'back-link\', extensionName: \'news\')}'
                 },
                 settings: {
                   templateLayout: settings.templateLayout,

--- a/Resources/Private/News/Templates/News/List.html
+++ b/Resources/Private/News/Templates/News/List.html
@@ -1,4 +1,5 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:n="http://typo3.org/ns/GeorgRinger/News/ViewHelpers" data-namespace-typo3-fluid="true">
+
 <f:if condition="{settings.hidePagination}">
     <f:then>
         <f:spaceless>
@@ -60,10 +61,10 @@
                     title: newsItem.title,
                     teaser: newsItem.teaser,
                     isTopNews: newsItem.istopnews,
-                    crdate: '{f:if(condition: newsItem.crdate, then: \'{newsItem.crdate -> f:format.date(format: \\\'M\ d\ Y\\\')}\')}',
-                    tstamp: '{f:if(condition: newsItem.tstamp, then: \'{newsItem.tstamp -> f:format.date(format: \\\'M\ d\ Y\\\')}\')}',
-                    datetime: '{f:if(condition: newsItem.datetime, then: \'{newsItem.datetime -> f:format.date(format: \\\'M\ d\ Y\\\')}\')}',
-                    archive: '{f:if(condition: newsItem.archive, then: \'{newsItem.archive -> f:format.date(format: \\\'Y-m-d\ H:i:s\\\')}\')}',
+                    crdate: '{f:if(condition: newsItem.crdate, then: \'{newsItem.crdate -> f:format.date(format: settings.dateFormat)}\')}',
+                    tstamp: '{f:if(condition: newsItem.tstamp, then: \'{newsItem.tstamp -> f:format.date(format: settings.dateFormat)}\')}',
+                    datetime: '{f:if(condition: newsItem.datetime, then: \'{newsItem.datetime -> f:format.date(format: settings.dateFormat)}\')}',
+                    archive: '{f:if(condition: newsItem.archive, then: \'{newsItem.archive -> f:format.date(format: settings.dateTimeFormat)}\')}',
                     author: {
                       author: newsItem.author,
                       authorEmail: newsItem.authorEmail

--- a/Resources/Private/News/Templates/News/List.html
+++ b/Resources/Private/News/Templates/News/List.html
@@ -79,7 +79,8 @@
                       alternativeTitle: newsItem.alternativeTitle
                     },
                     slug: '{n:link(newsItem: newsItem, settings: settings, uriOnly: 1)}',
-                    pathSegment: newsItem.pathSegment
+                    pathSegment: newsItem.pathSegment,
+                    moreLink: '{f:translate(key: \'more-link\', extensionName: \'news\')}'
                 }"/>
             </f:format.raw>
     </f:spaceless>

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "typo3/cms-core": "^10.0 || ^11.5"
   },
   "suggest": {
-    "friendsoftypo3/headless": "^2.0",
+  	"friendsoftypo3/headless": "^2.0 || ^3.0",
     "georgringer/news": "^9.0"
   },
   "extra": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,5 +1,6 @@
 <?php
 
+/** @phpstan-ignore-next-line */
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Headless News',
     'description' => 'This extension provides integration with news to output content from TYPO3 in JSON format.',
@@ -11,12 +12,12 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-10.0.99',
-            'frontend' => '9.5.0-10.0.99'
+            'typo3' => '9.5.0-11.5.99',
+            'frontend' => '9.5.0-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [
-            'headless' => '2.0.0-2.9.9'
-        ]
+            'headless' => '2.0.0-3.9.9',
+        ],
     ],
 ];

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,8 +12,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-11.5.99',
-            'frontend' => '9.5.0-11.5.99',
+            'typo3' => '10.0.0-11.5.99',
+            'frontend' => '10.0.0-11.5.99',
         ],
         'conflicts' => [],
         'suggests' => [


### PR DESCRIPTION
There are 2 new settings-fields, with that you can format the date in the json output. So in a multilingual environment you can configure the output over typoscript-conditions.

```
tt_content.list.fields.content.fields.data.news_pi1.settings {
    dateFormat = d.m.Y
    dateTimeFormat= d.m.Y H:i:s
}

```


No absolute URL in pagination, since the API URL != frontend URL