### PR TITLE
Fix import path for baseCe component

### DIFF
--- a/Resources/Private/News/Templates/Vue/CeNews_pi1.vue
+++ b/Resources/Private/News/Templates/Vue/CeNews_pi1.vue
@@ -5,7 +5,7 @@
   </div>
 </template>
 <script>
-import baseCe from "~typo3/components/content/mixins/baseCe";
+import baseCe from "~typo3/mixins/component/baseCe";
 import NewsList from "./Components/NewsList";
 import NewsSingle from "./Components/NewsSingle";
 


### PR DESCRIPTION
After installing nuxt-typo3-headless-news module, this compilation error occurs : 
```
This dependency was not found:                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                             
~typo3/components/content/mixins/baseCe in ./node_modules/babel-loader/lib??ref--2-0!./node_modules/vue-loader/lib??vue-loader-options!./node_modules/nuxt-typo3-headless-news/Resources/Private/News/Templates/Vue/CeNews_pi1.vue?vue&type=script&lang=js&
```

The path to baseCe component needs to be updated.