### PR TITLE
[BUGFIX] #24 Fix issue with news list view not rendering

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -29,3 +29,30 @@ tt_content.list {
     }
   }
 }
+
+
+// Since there is new content element ext:news 11
+tt_content.news_pi1 =< lib.contentElementWithHeader
+tt_content.news_pi1 {
+    fields {
+        content {
+            fields {
+                data = USER
+                data {
+                    userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
+                    vendorName = GeorgRinger
+                    extensionName = News
+                    pluginName = Pi1
+                    controller = News
+                    view < plugin.tx_news.view
+                    persistence < plugin.tx_news.persistence
+                    settings < plugin.tx_news.settings
+                    settings {
+                      dateFormat = M d Y
+                      dateTimeFormat = Y-m-d H:i:s
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tasks:
* With the introduction of content elements with ext:news, need to tweak the TS a bit.

To-Do's:
* Needs to register the same for news_list_sticky,news_detail,news_selectedlist,news_datemenu,categorylist,news_searchform,news_searchresult,taglist

Resolves: ##24